### PR TITLE
fix: Stripe min charge amount

### DIFF
--- a/collect-and-charge/src/stripe.ts
+++ b/collect-and-charge/src/stripe.ts
@@ -59,7 +59,7 @@ export async function payWithStripe(vaultUrl: string, tokenId: string) {
       Authorization: `Basic ${auth}`,
     },
     body: new URLSearchParams({
-      amount: "20",
+      amount: "50", // cents
       currency: "USD",
       payment_method: paymentMethod.id,
       automatic_payment_methods:


### PR DESCRIPTION
Stripe minimum charge is $0.50.

https://docs.stripe.com/api/payment_intents/create#create_payment_intent-amount

> Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).

